### PR TITLE
Add DOCX export

### DIFF
--- a/extractAllRulesFromWikiText.py
+++ b/extractAllRulesFromWikiText.py
@@ -18,6 +18,7 @@ import time
 import os
 import urllib.parse
 from datetime import datetime
+from html2docx import html2docx
 import sys
 import hashlib
 
@@ -319,14 +320,24 @@ class WikiTextLinkExtractor:
                     print(f"File content unchanged: {file_path}")
                     continue
 
-
                 # Save content to file
                 with open(file_path, 'w', encoding='utf-8') as f:
                     f.write(content)
-                    
+
                 print(f"Saved content to: {file_path}")
+
+                # Also create a docx file from the HTML content
+                try:
+                    docx_buffer = html2docx(content, filename)
+                    docx_path = os.path.join(output_dir, f"{filename}.docx")
+                    with open(docx_path, "wb") as df:
+                        df.write(docx_buffer.getvalue())
+                    print(f"Saved docx to: {docx_path}")
+                except Exception as e:
+                    print(f"Error converting to docx: {e}")
+
                 saved_count += 1
-                
+
                 # Add a small delay to be nice to the server
                 time.sleep(0.5)
                 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests>=2.31.0
 beautifulsoup4>=4.12.0
-lxml==4.9.3 
+lxml==4.9.3
+html2docx>=1.6.0


### PR DESCRIPTION
## Summary
- convert saved HTML files to DOCX using `html2docx`
- require `html2docx` in the environment

## Testing
- `pip install -r requirements.txt`
- `python - <<'EOF'
from extractAllRulesFromWikiText import WikiTextLinkExtractor
html='<html><body><p>Hello</p></body></html>'
ext=WikiTextLinkExtractor()
ext.extract_law_content=lambda url: html
count=ext.save_law_contents([{'url':'http://example.com/path','text':'Example','original_href':'http://example.com/path'}],max_links=1)
print('saved',count)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6845beaa7c1c8331a218b71d8c848b34