### PR TITLE
Use pandoc for docx export

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 lxml==4.9.3
-html2docx>=1.6.0


### PR DESCRIPTION
## Summary
- remove html2docx dependency
- convert HTML to DOCX using pandoc

## Testing
- `python -m py_compile extractAllRulesFromWikiText.py`
- `python extractAllRulesFromWikiText.py` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845c3b56d1c8331afd0448994194f48