### PR TITLE
Add MS Word friendly CSS

### DIFF
--- a/style_new.css
+++ b/style_new.css
@@ -1,0 +1,1202 @@
+
+.page-עמוד_ראשי.action-view #firstHeading {
+    display: none
+}
+
+.page-עמוד_ראשי.action-view #censorButton-div {
+    display: none
+}
+
+.allpagesredirect a {
+    color: grey
+}
+
+.newpage {
+    color: #FC6D00
+}
+
+pre {
+    overflow-x: auto
+}
+
+.mw-tag-problematic_words {
+    background-color: #FFE0E0
+}
+
+.updatedmarker {
+    font-weight: bold;
+    background-color: #9EFF9E !important
+}
+
+.action-info :target {
+    background-color: #DEF
+}
+
+.toplink {
+    position: absolute;
+    left: 35px
+}
+
+.mw-indicators {
+    height: 1px
+}
+
+#mw-fr-revisiontag,#mw-indicator-indicator-fr-review-status,.mw-fr-mobile-message-inline,.mw-fr-message-box {
+    display: none
+}
+
+.CategoryTreeLabelPage,.CategoryTreeParents,.CategoryTreeNotice {
+    font-style: normal
+}
+
+#siteNotice {
+    padding-top: 5px;
+    text-align: center
+}
+
+.IPA {
+    font-family: Chrysanthi Unicode,Doulos SIL,Gentium,GentiumAlt,Code2000,TITUS Cyberbit Basic,DejaVu Sans,Bitstream Vera Sans,Bitstream Cyberbit,Arial Unicode MS,Lucida Sans Unicode,Hiragino Kaku Gothic Pro,Matrix Unicode;
+    font-family : inherit
+}
+
+.graytext,.graytext a,.graytext a.stub .graytext a.extiw {
+    color: #777777 !important
+}
+
+.shortcut {
+    display: inline-block;
+    left: 12px;
+    font-size: 75%;
+    position: absolute;
+    top: 0.3em
+}
+
+.effect_on_hover {
+    border-top: solid 5px transparent
+}
+
+.effect_on_hover:hover {
+    border-top: 0
+}
+
+.low_opacity {
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
+    filter: alpha(opacity=40);
+    opacity: .40
+}
+
+.advanced {
+    background-color: #eee;
+    border: dotted 1pt
+}
+
+.future {
+    font-size: smaller;
+    background-color: #ccc
+}
+
+table.wikitable,table.prettytable {
+    background-color: #F9F9F9;
+    border-color: #AAAAAA;
+    border-style: solid;
+    border-width: 1px;
+    margin: 1em 1em 1em 0
+}
+
+table.wikitable th,table.wikitable td,table.prettytable th,table.prettytable td {
+    border-color: #AAAAAA;
+    border-style: solid;
+    border-width: 1px;
+    padding: 0.2em
+}
+
+table.wikitable th,table.prettytable th {
+    background-color: #F2F2F2;
+    text-align: center
+}
+
+table.wikitable caption,table.prettytable caption {
+    margin-left: inherit;
+    margin-right: inherit
+}
+
+.infobox {
+    border: 1px solid #aaaaaa;
+    background-color: #f9f9f9;
+    color: black;
+    margin-bottom: 0.5em;
+    margin-right: 1em;
+    padding: 0.2em;
+    display: inline-block;
+    clear: left
+}
+
+.infobox td,.infobox th {
+    vertical-align: top
+}
+
+.infobox caption {
+    font-size: larger;
+    margin-left: inherit
+}
+
+.infobox.bordered {
+    border-collapse: collapse
+}
+
+.infobox.bordered td,.infobox.bordered th {
+    border: 1px solid #aaaaaa
+}
+
+.infobox.bordered .borderless td,.infobox.bordered .borderless th {
+    border: 0
+}
+
+div.Boxmerge,div.NavFrame {
+    border-collapse: collapse;
+    border-color: #AAAAAA;
+    border-style: solid;
+    border-width: 1px;
+    font-size: 100%;
+    margin: 0;
+    padding: 2px;
+    text-align: center
+}
+
+div.Boxmerge div.NavFrame {
+    border-style: none;
+    border-style: hidden
+}
+
+div.NavFrame + div.NavFrame {
+    border-top-style: none;
+    border-top-style: hidden
+}
+
+div.NavPic {
+    background-color: #FFFFFF;
+    display: inline-block;
+    margin: 0;
+    margin-top: 0.5em;
+    padding: 2px
+}
+
+div.NavFrame div.NavHead {
+    background-color: #EFEFEF;
+    font-size: 100%;
+    font-weight: bold;
+    height: 1.6em;
+    position: relative
+}
+
+div.NavFrame p {
+    font-size: 100%
+}
+
+div.NavFrame div.NavContent {
+    font-size: 100%;
+    background-color: #FCFCFC
+}
+
+div.NavFrame div.NavContent p {
+    font-size: 100%
+}
+
+div.NavEnd {
+    clear: both;
+    line-height: 1px;
+    margin: 0;
+    padding: 0
+}
+
+a.NavToggle {
+    font-size: smaller;
+    font-weight: normal;
+    left: 3px;
+    position: absolute;
+    top: 0
+}
+
+table.navbox {
+    background-color: #f9f9f9;
+    border: 1px solid #aaa;
+    clear: both;
+    font-size: 90%;
+    margin: 1em 0 0;
+    padding: 2px;
+    text-align: center;
+    width: 100%
+}
+
+table.navbox th {
+    background-color: #ccf
+}
+
+div.columns dl,div.columns ol,div.columns ul,div.columns p:first-child {
+    margin-top: 0
+}
+
+div.columns {
+    orphans: 2;
+    widows: 2
+}
+
+div.hierarchical > dl {
+    margin-right: -1.6em
+}
+
+div.hierarchical dd,div.hierarchical dl,div.hierarchical ol,div.hierarchical ul {
+    margin-top: 0;
+    margin-bottom: 0.1em
+}
+
+div.hierarchical dd dd,div.hierarchical li li,div.hierarchical ul ul {
+    font-size: 80%
+}
+
+.hlist dl,.hlist ol,.hlist ul {
+    margin: 0;
+    padding: 0
+}
+
+.hlist dd,.hlist dt,.hlist li {
+    margin: 0;
+    display: inline
+}
+
+.hlist.inline,.hlist.inline dl,.hlist.inline ol,.hlist.inline ul,.hlist dl dl,.hlist dl ol,.hlist dl ul,.hlist ol dl,.hlist ol ol,.hlist ol ul,.hlist ul dl,.hlist ul ol,.hlist ul ul {
+    display: inline
+}
+
+.hlist .mw-empty-li,.hlist .mw-empty-elt {
+    display: none
+}
+
+.hlist dt:after {
+    content: ":"
+}
+
+.hlist dd:after,.hlist li:after {
+    content: " • ";
+    font-weight: bold
+}
+
+.hlist dd:last-child:after,.hlist dt:last-child:after,.hlist li:last-child:after {
+    content: none
+}
+
+.hlist dd dd:first-child:before,.hlist dd dt:first-child:before,.hlist dd li:first-child:before,.hlist dt dd:first-child:before,.hlist dt dt:first-child:before,.hlist dt li:first-child:before,.hlist li dd:first-child:before,.hlist li dt:first-child:before,.hlist li li:first-child:before {
+    content: " (";
+    font-weight: normal
+}
+
+.hlist dd dd:last-child:after,.hlist dd dt:last-child:after,.hlist dd li:last-child:after,.hlist dt dd:last-child:after,.hlist dt dt:last-child:after,.hlist dt li:last-child:after,.hlist li dd:last-child:after,.hlist li dt:last-child:after,.hlist li li:last-child:after {
+    content: ")";
+    font-weight: normal
+}
+
+.hlist ol {
+    counter-reset: listitem
+}
+
+.hlist ol > li {
+    counter-increment: listitem
+}
+
+.hlist ol > li:before {
+    content: " " counter(listitem) "\a0"
+}
+
+.hlist dd ol > li:first-child:before,.hlist dt ol > li:first-child:before,.hlist li ol > li:first-child:before {
+    content: " (" counter(listitem) "\a0"
+}
+
+.law,#law-content,#law-content h1,#law-content h2,#law-content h3,#law-content h4 {
+    text-align: justify;
+    margin: 0;
+    border: none;
+    font-size: 16px;
+    line-height: 1.15;
+    font-family: Alef,sans-serif;
+    hyphenate-character: "־"
+}
+
+h1.firstHeading > span.law {
+    display: none
+}
+
+.law p {
+    margin: 0 !important;
+    line-height: inherit
+}
+
+.law a,.law a[href].new,.law a[href].external,.law a[href].extiw {
+    color: inherit;
+    text-decoration: none;
+    background-image: none;
+    padding: 0;
+    border: none !important
+}
+
+.law-local a:hover,.law a:hover {
+    text-decoration: underline overline;
+    background-color: lightblue
+}
+
+.law-external a:hover,.law-external a.mw-redirect:hover,.law-external a[href].external:hover,.law-external a[href].extiw:hover {
+    text-decoration: underline overline;
+    background-color: pink
+}
+
+.law a.new:hover {
+    background-color: inherit;
+    text-decoration: none;
+    color: red
+}
+
+.law .selflink a:hover {
+    text-decoration: underline dotted lightblue;
+    background-color: inherit
+}
+
+.law-title,#law-content h1.law-title {
+    text-align: center;
+    font-size: 185%;
+    font-weight: bold;
+    text-wrap: balance;
+    padding: 0
+}
+
+.law-toc {
+    columns: 2 auto;
+    -moz-columns: 2 auto;
+    -webkit-columns: 2 auto;
+    text-align: start;
+    padding-bottom: 1em
+}
+
+.law-toc-1 {
+    font-weight: bold;
+    font-size: 110%;
+    padding-top: 3px;
+    padding-left:25px;text-indent: -25px
+}
+
+.law-toc-2 {
+    margin-left:25px;padding-top: 3px;
+    padding-left:25px;text-indent: -25px
+}
+
+.law-toc-3 {
+    font-size: 90%;
+    margin-left:50px;padding-left:25px;text-indent: -25px
+}
+
+.law-part,.law-section,.law-subsection,.law-subsubsection,#law-content h1,#law-content h2,#law-content h3,#law-content h4 {
+    text-align: center;
+    font-weight: normal;
+    text-wrap: balance;
+    padding: 0 6.25rem
+}
+
+.law-part,#law-content h1 {
+    font-size: 185%
+}
+
+.law-section,#law-content h2 {
+    font-size: 150%
+}
+
+.law-subsection,#law-content h3 {
+    font-size: 130%
+}
+
+.law-subsubsection,#law-content h4 {
+    font-size: 115%
+}
+
+.law-indent:not(:empty),.law-indent div:not(:empty) {
+    padding-left:2.5em;text-indent: -2.5em
+}
+
+.law-note {
+    font-size: smaller;
+    color: gray
+}
+
+.law-note .mwe-math-element img {
+    filter: invert(40%)
+}
+
+.law-desc > .law-note {
+    line-height: 90%;
+    letter-spacing: -0.03em
+}
+
+div.law-note p {
+    padding: 2px 0
+}
+
+.law-sec-note,.law-desc,.law-sec-desc,.law-number,.law-number1,.law-number2,.law-number3,.law-number4,.law-number5,.law-number6,.law-number7,.law-signatures li {
+}
+
+.law-sec-note:dir(ltr),.law-desc:dir(ltr),.law-sec-desc:dir(ltr),.law-number:dir(ltr),.law-number1:dir(ltr),.law-number2:dir(ltr),.law-number3:dir(ltr),.law-number4:dir(ltr),.law-number5:dir(ltr),.law-number6:dir(ltr),.law-number7:dir(ltr),.law-signatures li:dir(ltr) {
+}
+
+.law-sec-note {
+    position: absolute;
+    width: 95px;
+    font-size: 10.5px;
+    text-align: start;
+    margin-top: 15px;
+    margin-right:-95px;color: gray
+}
+
+.law-desc,.law-sec-desc {
+    font-size: smaller;
+    text-align: start;
+    padding: 2px 0;
+    line-height: 90%;
+    letter-spacing: -0.02em;
+    width: 9.5em;
+    margin-right:-95px}
+
+.law-sec-desc {
+    margin-top: 0.5em;
+    width: 7.5em;
+    margin-right:-7.5em}
+
+.law-main {
+    margin: 0;
+    margin-left:8.75em;padding: 0
+}
+
+.law-number,.law-number1,.law-number2,.law-number3,.law-number4,.law-number5,.law-number6,.law-number7 {
+    text-align: start;
+    white-space: nowrap;
+    padding-left:0.25em;margin-right:-2.5em;width: 2.2em;
+    height: 0;
+    position: relative;
+    z-index: 10
+}
+
+.law-number,.law-number1 {
+    width: 2.5em;
+    padding-left:0;margin-left:6.25em}
+
+.law-number2 {
+    margin-left:0}
+
+.law-number3 {
+    margin-left:2.5em}
+
+.law-number4 {
+    margin-left:5.0em}
+
+.law-number5 {
+    margin-left:7.5em}
+
+.law-number6 {
+    margin-left:10.0em}
+
+.law-number7 {
+    margin-left:12.5em}
+
+.law-float {
+    margin-right:2.5em;height: 1.2em
+}
+
+.law-content:not(:empty),.law-content1:not(:empty),.law-content2:not(:empty),.law-content3:not(:empty),.law-content4:not(:empty),.law-content5:not(:empty),.law-content6:not(:empty),.law-content7:not(:empty),.law p {
+    padding-bottom: 0.25em
+}
+
+.law-content,.law-content1 {
+    margin-left:0}
+
+.law-content2 {
+    margin-left:2.5em}
+
+.law-content3 {
+    margin-left:5.0em}
+
+.law-content4 {
+    margin-left:7.5em}
+
+.law-content5 {
+    margin-left:10.0em}
+
+.law-content6 {
+    margin-left:12.5em}
+
+.law-content7 {
+    margin-left:15.0em}
+
+.law-signatures {
+    text-align: start;
+    margin-left:6.25em}
+
+.law-signatures ul {
+    padding: 0;
+    margin: 0;
+    display: inline;
+    list-style: none;
+    width: 100%
+}
+
+.law-signatures li {
+    display: inline;
+    list-style: none;
+    width: 150px;
+    margin-bottom: 10px;
+    text-align: center;
+    line-height: 90%
+}
+
+hr.law-separator {
+    clear: both;
+    text-align: center;
+    padding-top: 1px;
+    margin: 10px 50px
+}
+
+.law-cleaner {
+    clear: both;
+    visibility: hidden;
+    height: 4px
+}
+
+.law table {
+    font-size: 90%;
+    text-align: initial;
+    border: 1px solid #AAA;
+    border-collapse: collapse;
+    margin-top: 0.5em !important;
+    margin-bottom: 0.5em !important
+}
+
+.law table td,.law table th {
+    vertical-align: top;
+    border: 1px solid #AAA
+}
+
+.law table th {
+    padding: 3px 3px;
+    background-color: #F2F2F2;
+    text-align: center;
+    font-weight: normal
+}
+
+.law table td {
+    padding: 3px 10px;
+    background-color: #F9F9F9
+}
+
+.law del {
+    background: #ffe6e6
+}
+
+.law ins {
+    background: #e6ffe6
+}
+
+.psuq {
+    font-family: Narkisim,Times,"Times New Roman",serif;
+    font-style: normal;
+    font-size: 1.4em;
+    color: #111155
+}
+
+.psuq2 {
+    font-family: David,Times,"Times New Roman",serif;
+    font-style: normal;
+    font-size: 1.8em;
+    color: #111155
+}
+
+.mfrj {
+    font-family: Times,"Times New Roman",serif;
+    font-style: normal;
+    font-size: 1.15em;
+    color: DarkGreen
+}
+
+div.nosahim div,span.nosahim span {
+    background-color: #efe
+}
+
+div.yamim div,span.yamim span {
+    background-color: #eef
+}
+
+.gmara_text {
+    font-size: 135%;
+    line-height: 23pt;
+    font-family: Narkisim
+}
+
+.gmara_rashi {
+    font-size: 120%
+}
+
+.gmara_ran {
+    font-size: 120%
+}
+
+.gmara_tosfot {
+    font-size: 100%
+}
+
+.mishna_text {
+    font-size: 135%;
+    line-height: 23pt;
+    font-family: narkisim
+}
+
+.mishna_bartenura {
+    font-size: 120%
+}
+
+.mishna_yom_tov {
+    font-size: 110%
+}
+
+.mishna_beyur {
+    font-size: 135%;
+    line-height: 23pt;
+    font-family: Narkisim
+}
+
+.mishna_beyur .editsection {
+    font-size: 35%;
+    font-family: Sans-serif
+}
+
+.mishna_chapters {
+    font-size: 135%;
+    line-height: 23pt
+}
+
+div.sources {
+    font-size: smaller;
+    background-color: #ccc
+}
+
+.mida {
+    display: inline-block;
+    width: 120px;
+    background-color: #ff8;
+    clear: left;
+    margin: 2px
+}
+
+.mida img {
+    height: 16px;
+    width: 16px;
+    margin: 2px;
+}
+
+.tova {
+    border-color: #0f0
+}
+
+.raa {
+    border-color: #f00
+}
+
+#p-navigation {
+    z-index: 1
+}
+
+#p-search {
+    z-index: 1
+}
+
+.beur {
+    font-family: David;
+    font-size: 165%;
+    line-height: 23pt
+}
+
+.TooltipPhrase {
+    border-bottom: 1px dotted #aaaadd;
+    cursor: help
+}
+
+.TooltipSpan {
+    display: none;
+    visibility: hidden
+}
+
+.TooltipTip {
+    width: 111pt;
+    z-index: 9;
+    position: absolute;
+    background-color: #ffc;
+    padding: 1px;
+    border: 1px #000 solid;
+    font-size: 11pt;
+    line-height: 13pt;
+    color: black;
+    font-family: sans-serif
+}
+
+.references {
+    font-size: 90%
+}
+
+span[rel="mw:referencedBy"]::before {
+    font-weight: bold;
+    content: "^ "
+}
+
+a[rel="mw:referencedBy"]::before {
+    font-weight: bold;
+    content: "^"
+}
+
+@media screen {
+    div.limitedRef {
+        height: 160px;
+        overflow-y: auto;
+        padding: 3px;
+        border: solid 1px
+    }
+
+    html > body div.limitedRef ol.references {
+        display: block !important
+    }
+}
+
+body.ns-104 .sidenote-left {
+    position: absolute;
+    left: 0;
+    width: 6em;
+    padding-right: 1em;
+    text-indent: 0;
+    text-align: left
+}
+
+body.ns-104 .sidenote-right {
+    position: absolute;
+    right: 0;
+    width: 6em;
+    padding-left: 1em;
+    text-indent: 0;
+    text-align: left
+}
+
+ol.references {
+    margin: 0
+}
+
+.mw-content-ltr ol.references,.mw-content-rtl ol.references {
+    margin: 0
+}
+
+ol.references li {
+    margin: 0 3em
+}
+
+.refDisplayRows ol,ol.refDisplayRows {
+    -webkit-column-count: 2;
+    -moz-column-count: 2;
+    column-count: 2;
+    -webkit-column-gap: 20px;
+    -moz-column-gap: 20px;
+    column-gap: 20px
+}
+
+ol.refDisplayScroll {
+    max-height: 20em;
+    overflow: auto;
+    margin: 0
+}
+
+ol.refDisplayHide {
+    display: none
+}
+
+.hebrewRefList .references {
+    list-style: hebrew
+}
+
+.upper-roman-list ol {
+    list-style: upper-roman
+}
+
+.lower-roman-list ol {
+    list-style: lower-roman
+}
+
+.upper-latin-list ol {
+    list-style: upper-latin
+}
+
+.lower-latin-list ol {
+    list-style: lower-latin
+}
+
+.hebrew-list ol {
+    list-style: hebrew
+}
+
+.toclimit-2 .toclevel-2,.toclimit-3 .toclevel-3,.toclimit-4 .toclevel-4,.toclimit-5 .toclevel-5,.toclimit-6 .toclevel-6,.toclimit-7 .toclevel-7 {
+    display: none
+}
+
+.toc-hide-numbers .tocnumber {
+    display: none
+}
+
+.flatToc li {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc li span.tocnumber {
+    display: none
+}
+
+.flatToc-1 li.toclevel-1 {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc-2 li.toclevel-1 {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc-2 li.toclevel-0 {
+    clear: right
+}
+
+.flatToc-3 li.toclevel-2 {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc-3 li.toclevel-1 {
+    clear: right
+}
+
+.flatToc-3 li.toclevel-0 {
+    clear: right
+}
+
+.flatToc-4 li.toclevel-3 {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc-4 li.toclevel-2 {
+    clear: right
+}
+
+.flatToc-5 li.toclevel-4 {
+    display: inline-block;
+    list-style-type: disc;
+    margin-right: 2em;
+    margin-left: 1em;
+    white-space: nowrap
+}
+
+.flatToc-5 li.toclevel-3 {
+    clear: right
+}
+
+.flatToc-1 li.toclevel-1 span.tocnumber {
+    display: none
+}
+
+.flatToc-2 li.toclevel-1 span.tocnumber {
+    display: none
+}
+
+.flatToc-2 li.toclevel-0 span.tocnumber {
+    display: none
+}
+
+.flatToc-3 li.toclevel-2 span.tocnumber {
+    display: none
+}
+
+.flatToc-3 li.toclevel-1 span.tocnumber {
+    display: none
+}
+
+.flatToc-4 li.toclevel-3 span.tocnumber {
+    display: none
+}
+
+.flatToc-4 li.toclevel-2 span.tocnumber {
+    display: none
+}
+
+.flatToc-5 li.toclevel-4 span.tocnumber {
+    display: none
+}
+
+.flatToc-5 li.toclevel-3 span.tocnumber {
+    display: none
+}
+
+.texts {
+    width: 33em;
+    text-align: justify;
+    margin: 0 auto;
+    font-family: Alef,Alef
+}
+
+.texts p {
+    text-indent: 2em
+}
+
+.poem-justify {
+    text-align: justify
+}
+
+.poem-justify p {
+    line-height: 1;
+    margin: 0;
+    padding: 0
+}
+
+.poem-justify p:after {
+    content: '';
+    display: inline-block;
+    width: 100%
+}
+
+.text-condensed-1,.tc-1 {
+    transform: scaleX(0.9);
+    transform-origin: right center 0px
+}
+
+.text-condensed-2,.tc-2 {
+    transform: scaleX(0.8);
+    transform-origin: right center 0px
+}
+
+.text-condensed-3,.tc-3 {
+    transform: scaleX(0.7);
+    transform-origin: right center 0px
+}
+
+.ui-dialog {
+    right: auto
+}
+
+.ui-autocomplete {
+    right: inherit
+}
+
+@media not print {
+    .printonly {
+        display: none
+    }
+}
+
+.mw-editTools a {
+    padding: 1.5px
+}
+
+.mw-editTools a:hover {
+    text-decoration: none;
+    background-color: #eaeaea
+}
+
+.mw-special-Upload .mw-editTools {
+    font-size: 90%
+}
+
+div#mw-indicator-\~ext-wikisource-download {
+    display: none
+}
+
+table.fmbox {
+    clear: both;
+    margin: 0.2em 0;
+    width: 100%;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    background: #f9f9f9
+}
+
+table.fmbox-system {
+    background: #f9f9f9
+}
+
+table.fmbox-warning {
+    border: 1px solid #bb7070;
+    background: #ffdbdb
+}
+
+table.fmbox-important {
+    background: #F5F5DC
+}
+
+table.fmbox-attention {
+    background: #FFFFCC
+}
+
+table.fmbox-editnotice {
+    background: transparent
+}
+
+th.mbox-text,td.mbox-text {
+    border: none;
+    padding: 0.25em;
+    width: 100%
+}
+
+td.mbox-image {
+    border: none;
+    padding: 2px 0.9em 2px 0;
+    text-align: center
+}
+
+td.mbox-imageright {
+    border: none;
+    padding: 2px 0 2px 0.9em;
+    text-align: center
+}
+
+td.mbox-empty-cell {
+    border: none;
+    padding: 0;
+    width: 1px
+}
+
+.vector-body-before-content {
+    overflow: unset
+}
+.printfooter,.graytext{
+    display: none;
+}
+
+@media print {
+    @page {
+        size: A4;
+        margin: 0.5in;
+        page-orientation: upright
+    }
+
+    body {
+        font-family: 'Hadasim CLM','Hadassah Friedlaender','David CLM','David';
+        font-size: 12pt
+    }
+
+    .printfooter,.mw-footer,.thumb,figure,table,ol,dl,ul,.mw-heading3,h3,.mw-heading4,h4,.mw-heading5,h5,.mw-heading6,h6 {
+        font-family: inherit
+    }
+
+    #contentSub {
+        display: none
+    }
+
+    .vector-header-container {
+        display: none
+    }
+
+    span.subpages,p.subpages,div#catlinks.catlinks,li#developers,span#cite-this-page,.skin-cologneblue #langlinks,.mw-jump-link,.noprint {
+        display: none
+    }
+
+    .printfooter,#footer-info-lastmod,#mw-data-after-content,#mw-footer-container,#mw-teleport-target,#p-dock-bottom {
+        display: none !important
+    }
+
+    .firstHeading::before {
+        display: none !important
+    }
+
+    .beur {
+        font-family: David;
+        font-size: 16pt;
+        line-height: 23pt;
+        background: red
+    }
+
+    .the_explain {
+        visibility: visible;
+        border: none;
+        padding: 0;
+        margin: 0;
+        position: static;
+        background-color: #888 line-height:1em
+    }
+
+    .click_for_details,.click_to_edit,.shortcut,.navigation,.links_in_title {
+        display: none
+    }
+
+    .NavFrame .NavContent p {
+        display: block;
+        padding: 0 2em 0 2em;
+        margin: 0
+    }
+
+    .NavFrame .NavContent p b {
+        padding: 0;
+        margin: 0
+    }
+
+    .NavFrame .NavHead p {
+    }
+
+    div.advanced {
+        background-color: #888
+    }
+
+    .law,#law-content,.law p,.law ol li,.law ul li {
+        font-size: 10pt;
+        font-family: Alef,FrankRuehl,serif
+    }
+
+    .law,#law-content,.law p {
+        width: auto;
+        margin: 0
+    }
+
+    .law-part,.law-section,.law-subsection,.law-subsubsection {
+        page-break-after: avoid
+    }
+
+    .law a.external.text:after {
+        display: none;
+        content: ""
+    }
+
+    .law a {
+        border: none !important
+    }
+
+    .law-signatures li {
+        width: 20%
+    }
+
+    .law-float {
+        margin-left: 35px
+    }
+
+    a.external.text:after {
+        display: none;
+        content: ""
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `style_new.css` derived from `style.css`
- replace logical margin/padding properties with physical equivalents
- remove `float` rules for better MS Word compatibility

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6846e422aa0c833197677e0a8dc62fba